### PR TITLE
fix image source lost in smart chunks

### DIFF
--- a/powerrag/server/services/split_service.py
+++ b/powerrag/server/services/split_service.py
@@ -161,7 +161,7 @@ class PowerRAGSplitService:
             else:
                 # Use config as-is for other parsers
                 chunks=[]
-                throw_error("Chunker not found")
+                raise ValueError(f"Chunker not found for parser_id: {parser_id}")
 
             # Ensure all chunks are strings and handle encoding
             processed_chunks = []
@@ -1034,6 +1034,13 @@ class ASTMarkdownChunker:
             elif node.type == "code_inline":
                 return f"`{node.content}`"
 
+        # Handle image nodes
+        if node.type == "image":
+            # Reconstruct markdown image syntax: ![alt](src)
+            alt = node.attrs.get('alt', '') if hasattr(node, 'attrs') and node.attrs else ''
+            src = node.attrs.get('src', '') if hasattr(node, 'attrs') and node.attrs else ''
+            return f"![{alt}]({src})"
+        
         # Handle nodes with children
         if hasattr(node, 'children') and node.children:
             content = "".join([self._render_node(child) for child in node.children])


### PR DESCRIPTION

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
image source link in markdown document is lost in smart chunk


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
process image type node by markdown-it