### PR TITLE
refactor: simplify string escaping in get_value_str and OBConnection …

### DIFF
--- a/rag/utils/ob_conn.py
+++ b/rag/utils/ob_conn.py
@@ -192,11 +192,9 @@ def get_default_value(column_name: str) -> Any:
 
 def get_value_str(value: Any) -> str:
     if isinstance(value, str):
-        cleaned_str = value.replace('\\', '\\\\')
-        cleaned_str = cleaned_str.replace('\n', '\\n')
-        cleaned_str = cleaned_str.replace('\r', '\\r')
-        cleaned_str = cleaned_str.replace('\t', '\\t')
-        return f"'{escape_string(cleaned_str)}'"
+        # escape_string already handles all necessary escaping for MySQL/OceanBase
+        # including backslashes, quotes, newlines, etc.
+        return f"'{escape_string(value)}'"
     elif isinstance(value, bool):
         return "true" if value else "false"
     elif value is None:
@@ -1288,19 +1286,9 @@ class OBConnection(DocStoreConnection):
                 elif k == "position_int":
                     d[k] = json.dumps([list(vv) for vv in v], ensure_ascii=False)
                 elif isinstance(v, list):
-                    # remove characters like '\t' for JSON dump and clean special characters
-                    cleaned_v = []
-                    for vv in v:
-                        if isinstance(vv, str):
-                            cleaned_str = vv.strip()
-                            cleaned_str = cleaned_str.replace('\\', '\\\\')
-                            cleaned_str = cleaned_str.replace('\n', '\\n')
-                            cleaned_str = cleaned_str.replace('\r', '\\r')
-                            cleaned_str = cleaned_str.replace('\t', '\\t')
-                            cleaned_v.append(cleaned_str)
-                        else:
-                            cleaned_v.append(vv)
-                    d[k] = json.dumps(cleaned_v, ensure_ascii=False)
+                    # json.dumps already handles all necessary escaping for JSON serialization
+                    # No need for manual escaping as it would cause double escaping
+                    d[k] = json.dumps(v, ensure_ascii=False)
                 else:
                     d[k] = v
 


### PR DESCRIPTION
…class

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

markdown chunk are escaped after edited and saved.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
- Removed manual string escaping in get_value_str and list handling in OBConnection.
- Updated to rely on built-in escaping mechanisms for MySQL/OceanBase and JSON serialization, preventing double escaping.
