### PR TITLE
hotfix: use locally built deps image in GHA

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -56,6 +56,31 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare dependencies
+        run: |
+          echo "Setting up Python..."
+          sudo apt-get update
+          sudo apt-get install -y python3 python3-pip
+
+          echo "Installing Python dependencies..."
+          python3 -m pip install --upgrade pip
+          python3 -m pip install huggingface-hub nltk
+
+          echo "Downloading dependencies..."
+          cd /mnt/powerrag
+          python3 download_deps.py
+
+          echo "Dependencies prepared successfully"
+
+      - name: Build dependency image
+        run: |
+          echo "Building dependency image..."
+          docker build \
+            --file /mnt/powerrag/Dockerfile.deps \
+            --tag infiniflow/ragflow_deps:latest \
+            /mnt/powerrag
+          echo "Dependency image built successfully"
+
       - name: Build and push image
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Prepare dependencies for arm64
-        if: matrix.platform == 'linux/arm64'
+      - name: Prepare dependencies
         run: |
           echo "Setting up Python..."
           sudo apt-get update
@@ -77,10 +76,9 @@ jobs:
           
           echo "Dependencies prepared successfully"
 
-      - name: Build dependency image for arm64
-        if: matrix.platform == 'linux/arm64'
+      - name: Build dependency image
         run: |
-          echo "Building dependency image for arm64 build..."
+          echo "Building dependency image..."
           docker build \
             --file /mnt/powerrag/Dockerfile.deps \
             --tag infiniflow/ragflow_deps:latest \


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

Ragflow has updated the ragflow_deps Docker image recently, and we should switch to using a locally built image to avoid errors caused by the image change.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->

Update the GHA to use locally built ragflow_deps docker image.