### PR TITLE
fix(ob_conn): avoid reusing SQLAlchemy Column objects in DDL

### DIFF
--- a/rag/utils/ob_conn.py
+++ b/rag/utils/ob_conn.py
@@ -656,7 +656,7 @@ class OBConnection(DocStoreConnection):
 
         self.client.create_table(
             table_name=table_name,
-            columns=column_definitions,
+            columns=[c.copy() for c in column_definitions],
             **table_options,
         )
         logger.info(f"Created table '{table_name}'.")
@@ -709,7 +709,7 @@ class OBConnection(DocStoreConnection):
         try:
             self.client.add_columns(
                 table_name=table_name,
-                columns=[column],
+                columns=[column.copy()],
             )
             logger.info(f"Added column '{column.name}' to table '{table_name}'.")
         except Exception as e:


### PR DESCRIPTION
Do not reuse column in DDL to fix error `sqlalchemy.exc.ArgumentError: Column object 'id' already assigned to Table xxx`.