### PR TITLE
fix(docker): fix entrypoint.sh syntax error and duplicate YAML key

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -99,6 +99,7 @@ for arg in "$@"; do
     --powerrag-port=*)
       POWERRAG_PORT="${arg#*=}"
       shift
+      ;;
     --init-superuser)
       INIT_SUPERUSER_ARGS="--init-superuser"
       shift

--- a/docker/service_conf.yaml.template
+++ b/docker/service_conf.yaml.template
@@ -43,10 +43,6 @@ redis:
   username: '${REDIS_USERNAME:-}'
   password: '${REDIS_PASSWORD:-infini_rag_flow}'
   host: '${REDIS_HOST:-redis}:6379'
-oceanbase:
-  scheme: 'mysql' # set 'mysql' to create connection using mysql config
-  config:
-    db_name: '${OCEANBASE_DOC_DBNAME:-test}'
 gotenberg:
   url: '${GOTENBERG_URL}'
   timeout: 60


### PR DESCRIPTION
Fixes container startup failures with:

- Add missing `;;` terminator for --powerrag-port case branch in entrypoint.sh (Error log: ```./entrypoint.sh: line 102: syntax error near unexpected token `)'```)
- Remove duplicate `oceanbase` key in service_conf.yaml.template (Error log: `"DuplicateKeyError: found duplicate key oceanbase"`)
