### PR TITLE
ci: add gate job for docs-only PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,15 +2,35 @@ name: pr
 
 on:
   pull_request:
-    paths-ignore:
-      - "**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run_build: ${{ steps.filter.outputs.run_build }}
+    steps:
+      - id: filter
+        name: Detect whether non-Markdown files changed
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run_build:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.mdx'
+      - name: Gate summary
+        run: echo "run_build=${{ steps.filter.outputs.run_build }}"
+
   build:
+    needs: gate
+    if: needs.gate.outputs.run_build == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Run PR workflow for all pull requests and always report a required status check via a lightweight `gate` job.
- Skip the heavy `build` job for Markdown-only changes.

## Test plan
- [ ] Open a PR that changes only `*.md` / `*.mdx` and confirm `pr / gate` passes and merge is unblocked.
- [ ] Open a PR that changes non-Markdown files and confirm `pr / build` still runs.