### PR TITLE
fix: use module-level access for STORAGE_IMPL to avoid stale None binding

### DIFF
--- a/powerrag/parser/mineru_parser.py
+++ b/powerrag/parser/mineru_parser.py
@@ -26,7 +26,7 @@ from io import BytesIO
 import pdfplumber
 from typing import Union, Dict, TypedDict, Tuple
 from api.utils.configs import get_base_config
-from common.settings import STORAGE_IMPL
+from common import settings
 from PIL import Image
 
 LOCK_KEY_pdfplumber = "global_shared_lock_pdfplumber"
@@ -246,7 +246,7 @@ class MinerUPdfParser:
                 img_bytes = base64.b64decode(img_base64)
 
                 # Store image in OceanBase
-                STORAGE_IMPL.put(output_dir, img_name, img_bytes)
+                settings.STORAGE_IMPL.put(output_dir, img_name, img_bytes)
 
                 # Generate URL for the image using PowerRAG image access endpoint
                 # Get PowerRAG server configuration

--- a/powerrag/parser/vllm_parser.py
+++ b/powerrag/parser/vllm_parser.py
@@ -24,7 +24,7 @@ from io import BytesIO
 import pdfplumber
 from typing import Union, Dict, TypedDict, Tuple, List, Optional
 from api.utils.configs import get_base_config
-from common.settings import STORAGE_IMPL
+from common import settings
 from openai import OpenAI
 from PIL import Image
 import io
@@ -413,7 +413,7 @@ class VllmParser:
                         img_bytes = buffered.getvalue()
                         
                         # Store image in storage (bucket)
-                        STORAGE_IMPL.put(output_dir, img_filename, img_bytes)
+                        settings.STORAGE_IMPL.put(output_dir, img_filename, img_bytes)
                         
                         # Generate URL for the image
                         powerrag_config = get_base_config("powerrag", {}) or {}
@@ -660,7 +660,7 @@ class VllmParser:
                 img_bytes = base64.b64decode(img_base64)
 
                 # Store image in storage
-                STORAGE_IMPL.put(output_dir, img_name, img_bytes)
+                settings.STORAGE_IMPL.put(output_dir, img_name, img_bytes)
 
                 # Generate URL for the image using RAGFlow image access endpoint
                 # Get RAGFlow server configuration

--- a/powerrag/server/services/convert_service.py
+++ b/powerrag/server/services/convert_service.py
@@ -28,7 +28,7 @@ from typing import Dict, Any
 
 from api.db.services.document_service import DocumentService
 from api.db.services.file2document_service import File2DocumentService
-from common.settings import STORAGE_IMPL
+from common import settings
 from powerrag.parser import MinerUPdfParser, DotsOcrParser
 
 logger = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ class PowerRAGConvertService:
             
             # Get binary data
             bucket, name = File2DocumentService.get_storage_address(doc_id=doc_id)
-            binary = STORAGE_IMPL.get(bucket, name)
+            binary = settings.STORAGE_IMPL.get(bucket, name)
             
             if not binary:
                 raise ValueError(f"Document binary not found for {doc_id}")

--- a/powerrag/server/services/parse_service.py
+++ b/powerrag/server/services/parse_service.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from api.db.services.document_service import DocumentService
 from api.db.services.file2document_service import File2DocumentService
 from common.constants import ParserType
-from common.settings import STORAGE_IMPL
+from common import settings
 
 # Import split service for text chunking
 from powerrag.server.services.split_service import PowerRAGSplitService
@@ -119,7 +119,7 @@ class PowerRAGParseService:
             parser_config = doc.get["parser_config"]
             # Get document binary data from storage
             bucket, name = File2DocumentService.get_storage_address(doc_id=doc_id)
-            binary = STORAGE_IMPL.get(bucket, name)
+            binary = settings.STORAGE_IMPL.get(bucket, name)
             
             if not binary:
                 raise ValueError(f"Document binary data not found for {doc_id}")
@@ -662,7 +662,7 @@ class PowerRAGParseService:
             if not bucket or not name:
                 raise ValueError(f"Invalid storage address for document {doc_id}: bucket={bucket}, name={name}")
             
-            storage = STORAGE_IMPL
+            storage = settings.STORAGE_IMPL
             
             if not storage:
                 raise ValueError("Storage implementation not available")


### PR DESCRIPTION

`from common.settings import STORAGE_IMPL` captures the value at import time (None), which is never updated when init_settings() later reassigns it. Switch to `from common import settings` and access via `settings.STORAGE_IMPL` so the current value is resolved at call time.